### PR TITLE
 🔀 🐛🌐 [so/hotkeys] fix for schoolingoverview and nl_NL translation hotkeys

### DIFF
--- a/src/modules/hotkeys/i18n/nl_NL.root.json
+++ b/src/modules/hotkeys/i18n/nl_NL.root.json
@@ -50,8 +50,8 @@
             },
             "missionlist": {
                 "eclSort": {
-                    "open": "Open selection menu",
-                    "title": "Mission sorting"
+                    "open": "Open selectie menu",
+                    "title": "Meldingen sortering"
                 },
                 "search": { "focus": "focus invoerveld", "title": "Zoekveld" },
                 "title": "Meldingenlijst"

--- a/src/modules/schoolingOverview/assets/getSchoolings.ts
+++ b/src/modules/schoolingOverview/assets/getSchoolings.ts
@@ -21,7 +21,7 @@ export default (
     doc.querySelectorAll('#schooling_own_table tbody tr').forEach(schooling => {
         const btn = schooling.querySelector('a.btn-success') as HTMLLinkElement;
         if (!btn) return;
-        const name = btn.textContent || '';
+        const name = btn.textContent?.trim() || '';
         if (!ownSchoolings.amounts.hasOwnProperty(name))
             ownSchoolings.amounts[name] = 0;
         ownSchoolings.amounts[name]++;
@@ -54,7 +54,7 @@ export default (
     ).forEach(schooling => {
         const btn = schooling.querySelector('a.btn-success') as HTMLLinkElement;
         if (!btn) return;
-        const name = btn.textContent || '';
+        const name = btn.textContent?.trim() || '';
         const category =
             name?.match(/^.*?-/u)?.[0].replace('-', '').trim() || '';
         if (!openSchoolings.amounts.hasOwnProperty(name))


### PR DESCRIPTION
<!-- Please start the title of this PR with 🔀 -->

<!-- Note: Please stick to this template to help us keep LSSM clean! -->
**What kind of update does this PR provide?** *Please check*
<!-- you can check a checkbox by replacing the space ` ` with a `x`: [x] -->
- [x] new translations / updated translations / translation fixes
- [ ] a new feature
- [ ] a new module
- [x] a bugfix for an existing feature / module
- [ ] improvement of style or user experience
- [ ] other: *Please fill out*

<!-- If PR contains translations -->
<!-- if the PR does only contain translations, please adjust the PR title similar this:
    🔀🌐 [xx_XX] add/update translations for {module}
-->
**Which language(s) did you add/update translations for?**
*use the xx_XX notation for exact language!*
* nl_NL
<!-- END IF translations -->

**What is included in your update?**
* new translations for hotkey nl_NL
* fixed bug in the schoolingoverview when the schooling name has an extra space in the ingame buttons, see additional notes for screenshots.

**Additional notes**

![image](https://user-images.githubusercontent.com/65117490/184852614-09c339b9-36e4-4c40-acb0-619f964fda36.png)
Currently this will cause that the schooling is shown double in the open schooling overview because the schooling in the code doesn't have the space. To fix this for now and for future similar problems, we could trim the text, so it's the same. If the game fixes the name also, this fix will not cause new problems with it. 
![image](https://user-images.githubusercontent.com/65117490/184853303-9ae3e334-2df8-4607-b8b8-910e3912b84e.png)
![image](https://user-images.githubusercontent.com/65117490/184853451-9f392380-3e48-4909-ab29-b0ec23540cd0.png)
