### PR TITLE
🔀✨[so] hide schoolingstable settings

### DIFF
--- a/src/modules/redesign/components/schoolings.vue
+++ b/src/modules/redesign/components/schoolings.vue
@@ -4,11 +4,9 @@
             :open-schoolings="schoolings.openSchoolings.amounts"
             :own-schoolings="schoolings.ownSchoolings.amounts"
         ></schoolings-overview>
-        <h3>{{ lightbox.$sm('ownSchoolings') }}</h3>
         <own-schooling-tabs
             :tabs="schoolings.ownSchoolings.tabs"
         ></own-schooling-tabs>
-        <h3>{{ lightbox.$sm('openSchoolings') }}</h3>
         <open-schooling-tabs
             :tabs="schoolings.openSchoolings.tabs"
         ></open-schooling-tabs>

--- a/src/modules/schoolingOverview/components/openSchoolingTabs.vue
+++ b/src/modules/schoolingOverview/components/openSchoolingTabs.vue
@@ -4,21 +4,19 @@
             id="openschooling-title-wrapper"
             style="display: flex; margin-bottom: 1rem"
         >
-            <span style="margin-right: 2rem">
+            <h3>
+                {{ $t('modules.schoolingOverview.open') }}
                 <button
-                    class="btn pull-right"
+                    class="btn btn-xs"
                     :class="`btn-${collapsed ? 'success' : 'danger'}`"
                     @click="toggleCollapse"
                     id="openschooling-collapse-button"
-                    style="position: relative; top: 25%"
+                    style="margin-left: 1rem"
                 >
                     <font-awesome-icon
                         :icon="collapsed ? faExpandAlt : faCompressAlt"
                     />
                 </button>
-            </span>
-            <h3>
-                {{ $t('modules.schoolingOverview.open') }}
             </h3>
         </div>
         <tabs

--- a/src/modules/schoolingOverview/components/openSchoolingTabs.vue
+++ b/src/modules/schoolingOverview/components/openSchoolingTabs.vue
@@ -1,42 +1,72 @@
 <template>
-    <tabs :on-select="(_, index) => (currentTab = tabTitles[index])">
-        <tab v-for="tab in tabTitles" :key="tab" :title="tab">
-            <enhanced-table
-                :head="heads"
-                :table-attrs="{ class: 'table table-striped' }"
-                @sort="setSorting"
-                :sort="sort"
-                :sort-dir="sortDir"
-                :search="search"
-                @search="s => (search = s)"
-            >
-                <tr
-                    v-for="(schooling, id) in schoolings"
-                    :key="id"
-                    class="schooling_opened_table_searchable"
+    <div>
+        <div
+            id="openschooling-title-wrapper"
+            style="display: flex; margin-bottom: 1rem"
+        >
+            <span style="margin-right: 2rem">
+                <button
+                    class="btn pull-right"
+                    :class="`btn-${collapsed ? 'success' : 'danger'}`"
+                    @click="toggleCollapse"
+                    id="openschooling-collapse-button"
+                    style="position: relative; top: 25%"
                 >
-                    <td>
-                        <a
-                            class="btn btn-success"
-                            :href="`/schoolings/${schooling.id}`"
-                        >
-                            {{ schooling.name }}
-                        </a>
-                    </td>
-                    <td>{{ schooling.seats }}</td>
-                    <td>{{ schooling.price }}</td>
-                    <td :id="`education_schooling_${schooling.id}`">
-                        {{ schooling.end }}
-                    </td>
-                    <td v-html="schooling.owner"></td>
-                </tr>
-            </enhanced-table>
-        </tab>
-    </tabs>
+                    <font-awesome-icon
+                        :icon="collapsed ? faExpandAlt : faCompressAlt"
+                    />
+                </button>
+            </span>
+            <h3>
+                {{ $t('modules.schoolingOverview.open') }}
+            </h3>
+        </div>
+        <tabs
+            :on-select="(_, index) => (currentTab = tabTitles[index])"
+            :style="collapsed ? { display: 'none' } : {}"
+        >
+            <tab v-for="tab in tabTitles" :key="tab" :title="tab">
+                <enhanced-table
+                    :head="heads"
+                    :table-attrs="{ class: 'table table-striped' }"
+                    @sort="setSorting"
+                    :sort="sort"
+                    :sort-dir="sortDir"
+                    :search="search"
+                    @search="s => (search = s)"
+                >
+                    <tr
+                        v-for="(schooling, id) in schoolings"
+                        :key="id"
+                        class="schooling_opened_table_searchable"
+                    >
+                        <td>
+                            <a
+                                class="btn btn-success"
+                                :href="`/schoolings/${schooling.id}`"
+                            >
+                                {{ schooling.name }}
+                            </a>
+                        </td>
+                        <td>{{ schooling.seats }}</td>
+                        <td>{{ schooling.price }}</td>
+                        <td :id="`education_schooling_${schooling.id}`">
+                            {{ schooling.end }}
+                        </td>
+                        <td v-html="schooling.owner"></td>
+                    </tr>
+                </enhanced-table>
+            </tab>
+        </tabs>
+    </div>
 </template>
 
 <script lang="ts">
 import Vue from 'vue';
+
+import { faCompressAlt } from '@fortawesome/free-solid-svg-icons/faCompressAlt';
+import { faExpandAlt } from '@fortawesome/free-solid-svg-icons/faExpandAlt';
+import { useSettingsStore } from '@stores/settings';
 
 import type {
     OpenSchoolingTabs,
@@ -76,6 +106,8 @@ export default Vue.extend<
         const all = this.$t('modules.schoolingOverview.all') as string;
         const tabTitles = [all, ...Object.keys(this.$t('schoolings'))];
         return {
+            faCompressAlt,
+            faExpandAlt,
             heads,
             tabTitles,
             currentTab: tabTitles[0],
@@ -83,6 +115,8 @@ export default Vue.extend<
             sort: 'name',
             sortDir: 'asc',
             all,
+            collapsed: false,
+            settingsStore: useSettingsStore(),
         } as OpenSchoolingTabs;
     },
     computed: {
@@ -112,6 +146,22 @@ export default Vue.extend<
                 s === this.sort && this.sortDir === 'asc' ? 'desc' : 'asc';
             this.sort = s;
         },
+        toggleCollapse() {
+            this.collapsed = !this.collapsed;
+            this.settingsStore.setSetting({
+                moduleId: 'schoolingOverview',
+                settingId: 'hide_openschooling',
+                value: this.collapsed,
+            });
+        },
+    },
+    mounted() {
+        this.settingsStore
+            .getSetting<boolean>({
+                moduleId: 'schoolingOverview',
+                settingId: 'hide_openschooling',
+            })
+            .then(collapsed => (this.collapsed = collapsed));
     },
     props: {
         tabs: {

--- a/src/modules/schoolingOverview/components/ownSchoolingTabs.vue
+++ b/src/modules/schoolingOverview/components/ownSchoolingTabs.vue
@@ -1,24 +1,22 @@
 <template>
     <div>
         <div
-            id="openschooling-title-wrapper"
+            id="ownschooling-title-wrapper"
             style="display: flex; margin-bottom: 1rem"
         >
-            <span style="margin-right: 2rem">
+            <h3>
+                {{ $t('modules.schoolingOverview.own') }}
                 <button
-                    class="btn pull-right"
+                    class="btn btn-xs"
                     :class="`btn-${collapsed ? 'success' : 'danger'}`"
                     @click="toggleCollapse"
-                    id="openschooling-collapse-button"
-                    style="position: relative; top: 25%"
+                    id="ownschooling-collapse-button"
+                    style="margin-left: 1rem"
                 >
                     <font-awesome-icon
                         :icon="collapsed ? faExpandAlt : faCompressAlt"
                     />
                 </button>
-            </span>
-            <h3>
-                {{ $t('modules.schoolingOverview.own') }}
             </h3>
         </div>
         <tabs

--- a/src/modules/schoolingOverview/main.ts
+++ b/src/modules/schoolingOverview/main.ts
@@ -27,6 +27,7 @@ export default <ModuleMainFunction>(({ LSSM }) => {
         '#schooling_own_table'
     );
     if (ownTable) {
+        ownTable.previousElementSibling?.remove();
         new LSSM.$vue({
             pinia: LSSM.$pinia,
             i18n: LSSM.$i18n,
@@ -39,6 +40,7 @@ export default <ModuleMainFunction>(({ LSSM }) => {
         '#schooling_opened_table'
     );
     if (openTable) {
+        openTable.previousElementSibling?.previousElementSibling?.remove();
         document
             .querySelector(
                 '.search_input_field[search_class="schooling_opened_table_searchable"]'

--- a/src/modules/schoolingOverview/register.json
+++ b/src/modules/schoolingOverview/register.json
@@ -1,1 +1,1 @@
-{ "github": 14, "location": "^/schoolings/?$" }
+{ "github": 14, "location": "^/schoolings/?$", "settings": true }

--- a/src/modules/schoolingOverview/settings.ts
+++ b/src/modules/schoolingOverview/settings.ts
@@ -1,0 +1,7 @@
+import type { Hidden } from 'typings/Setting';
+import type { ModuleSettingFunction } from 'typings/Module';
+
+export default (() => ({
+    hide_ownschooling: <Hidden>{ type: 'hidden', default: false },
+    hide_openschooling: <Hidden>{ type: 'hidden', default: false },
+})) as ModuleSettingFunction;

--- a/typings/modules/SchoolingOverview/OpenSchoolingTabs.d.ts
+++ b/typings/modules/SchoolingOverview/OpenSchoolingTabs.d.ts
@@ -1,4 +1,6 @@
+import type { IconDefinition } from '@fortawesome/free-solid-svg-icons';
 import type { OpenSchoolings } from 'typings/modules/SchoolingOverview/main';
+import type { useSettingsStore } from '@stores/settings';
 
 export interface OpenSchooling {
     end: number;
@@ -10,6 +12,8 @@ export interface OpenSchooling {
 }
 
 export interface OpenSchoolingTabs {
+    faCompressAlt: IconDefinition;
+    faExpandAlt: IconDefinition;
     heads: Record<
         string,
         {
@@ -22,6 +26,8 @@ export interface OpenSchoolingTabs {
     sort: 'end' | 'name' | 'owner' | 'price' | 'seats';
     sortDir: string;
     all: string;
+    collapsed: boolean;
+    settingsStore: ReturnType<typeof useSettingsStore>;
 }
 
 export interface OpenSchoolingTabsComputed {
@@ -30,6 +36,7 @@ export interface OpenSchoolingTabsComputed {
 
 export interface OpenSchoolingTabsMethods {
     setSorting(s: OpenSchoolingTabs['sort']): void;
+    toggleCollapse(): void;
 }
 
 export interface OpenSchoolingTabsProps {

--- a/typings/modules/SchoolingOverview/OwnSchoolingTabs.d.ts
+++ b/typings/modules/SchoolingOverview/OwnSchoolingTabs.d.ts
@@ -1,4 +1,6 @@
+import type { IconDefinition } from '@fortawesome/fontawesome-svg-core';
 import type { OwnSchoolings } from 'typings/modules/SchoolingOverview/main';
+import type { useSettingsStore } from '@stores/settings';
 
 export interface OwnSchooling {
     end: number;
@@ -8,6 +10,8 @@ export interface OwnSchooling {
 }
 
 export interface OwnSchoolingTabs {
+    faCompressAlt: IconDefinition;
+    faExpandAlt: IconDefinition;
     heads: Record<
         string,
         {
@@ -20,6 +24,8 @@ export interface OwnSchoolingTabs {
     sort: 'end' | 'name' | 'owner';
     sortDir: string;
     all: string;
+    collapsed: boolean;
+    settingsStore: ReturnType<typeof useSettingsStore>;
 }
 
 export interface OwnSchoolingTabsComputed {
@@ -28,6 +34,7 @@ export interface OwnSchoolingTabsComputed {
 
 export interface OwnSchoolingTabsMethods {
     setSorting(s: OwnSchoolingTabs['sort']): void;
+    toggleCollapse(): void;
 }
 
 export interface OwnSchoolingTabsProps {


### PR DESCRIPTION
<!-- Please start the title of this PR with 🔀 -->

<!-- Note: Please stick to this template to help us keep LSSM clean! -->
**What kind of update does this PR provide?** *Please check*
<!-- you can check a checkbox by replacing the space ` ` with a `x`: [x] -->
- [ ] new translations / updated translations / translation fixes
- [x] a new feature
- [ ] a new module
- [ ] a bugfix for an existing feature / module
- [ ] improvement of style or user experience
- [ ] other: *Please fill out*

<!-- If PR contains translations -->
<!-- if the PR does only contain translations, please adjust the PR title similar this:
    🔀🌐 [xx_XX] add/update translations for {module}
-->
**Which language(s) did you add/update translations for?**
*use the xx_XX notation for exact language!*
<!-- END IF translations -->

**What is included in your update?**
* buttons to hide the tables in the schoolingOverview. 

**Additional notes**
It's compatible with both modules (schoolingOverview and redesign). It saves the last position in a hidden setting. 
No translations are needed for this setting. 
It's useable when you started a lot of schooling and need to scroll down to see the open schoolings. 