### PR TITLE
🔀👷‍♂️[build] replace `set-output` commands

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
 
             - name: Get yarn cache directory path
               id: yarn_cache_dir
-              run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+              run: echo "dir=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 
             - name: Restore Cache
               uses: actions/cache@v3
@@ -161,9 +161,9 @@ jobs:
             - name: '[💬] set output'
               id: output
               run: |
-                  echo "::set-output name=branch::${{ env.BRANCH }}"
+                  echo "branch=${{ env.BRANCH }}" >> $GITHUB_OUTPUT
                   echo "VERSION=$(grep '"version":' ./package.json | awk -F: '{ print $2 }' | sed 's/[",]//g' | tr -d '[:space:]')" >> $GITHUB_ENV
-                  echo "::set-output name=version::$VERSION"
+                  echo "version=$VERSION" >> $GITHUB_OUTPUT
                   echo "CHANGED_FILES=$(git status -s | wc -l)" >> $GITHUB_ENV
 
             - name: '[📦] zip files'


### PR DESCRIPTION
- [ ] new translations / updated translations / translation fixes
- [ ] a new feature
- [ ] a new module
- [ ] a bugfix for an existing feature / module
- [ ] improvement of style or user experience
- [x] other: CI

**What is included in your update?**
* patches for GH Actions ("set-output" commands)

**Additional notes**
This is due to a change it github actions by GH. See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ for more details
