### PR TITLE
🔀 🐛  [emv] Added Ambulance Officer ID to OTL vehicle array.

### DIFF
--- a/src/modules/extendedCallWindow/i18n/en_GB.json
+++ b/src/modules/extendedCallWindow/i18n/en_GB.json
@@ -145,7 +145,7 @@
                     "Operational Team Leader",
                     "Operational Team Leaders"
                 ],
-                "vehicles": [20, 31]
+                "vehicles": [20, 31, 34]
             },
             { "texts": ["Traffic Car", "Traffic Cars"], "vehicles": [24, 25] },
             { "texts": ["ATV Carrier", "ATV Carriers"], "vehicles": [30] },


### PR DESCRIPTION
**What kind of update does this PR provide?** *Please check*
- [ ] new translations / updated translations / translation fixes
- [ ] a new feature
- [ ] a new module
- [X] a bugfix for an existing feature / module
- [ ] improvement of style or user experience
- [ ] other: *Please fill out*

**What is included in your update?**
* fixed bug for enhanced missing vehicles to recognise ambulance officer as meeting OTL requirement in GB version of game.

**Additional notes**
Ambulance Officer can act as an OTL in GB version of game.
