### PR TITLE
🔀≈ instead of ~ for approximate numbers

### DIFF
--- a/src/modules/extendedCallList/assets/averageCredits.ts
+++ b/src/modules/extendedCallList/assets/averageCredits.ts
@@ -58,7 +58,7 @@ export default (
                 `.${wrapperClass} span`
             );
             if (span) {
-                span.textContent = `~ ${
+                span.textContent = `≈ ${
                     missionsById[
                         getMissionTypeFromPanel(missionPanel)
                     ]?.average_credits?.toLocaleString() ?? '–'

--- a/src/modules/extendedCallList/assets/averageCredits.ts
+++ b/src/modules/extendedCallList/assets/averageCredits.ts
@@ -46,7 +46,7 @@ export default (
                 span.style.setProperty('color', 'black');
 
             const missionSpecs: Mission | undefined = missionsById[missionType];
-            span.textContent = `~ ${
+            span.textContent = `≈ ${
                 missionSpecs?.average_credits?.toLocaleString() ?? '–'
             }`;
             wrapper.append(span);


### PR DESCRIPTION
≈ instead of ~ for approximate numbers for average credits at module extended Call List.

Source: [https://en.wikipedia.org/wiki/Glossary_of_mathematical_symbols#Equality,_equivalence_and_similarity](Wiki 1) and [https://en.wikipedia.org/wiki/Approximation#Typography](Wiki 2).

Untested!