### PR TITLE
🐛🌐 [UK] fix missing/wrong unit in ECW

### DIFF
--- a/src/modules/extendedCallWindow/i18n/en_GB.json
+++ b/src/modules/extendedCallWindow/i18n/en_GB.json
@@ -174,7 +174,7 @@
                 "texts": ["Flood Rescue Unit", "Flood Rescue Units"],
                 "vehicles": [61]
             },
-            { "texts": ["CRV", "CRVs"], "vehicles": [57] },
+            { "texts": ["CRV", "CRVs"], "vehicles": [57, 58, 59] },
             {
                 "texts": ["Coastguard Commander", "Coastguard Commanders"],
                 "vehicles": [60]

--- a/src/modules/extendedCallWindow/i18n/en_GB.json
+++ b/src/modules/extendedCallWindow/i18n/en_GB.json
@@ -78,6 +78,20 @@
                 ],
                 "vehicles": [4, 16, 38, 43]
             },
+                        {
+                "texts": [
+                    "Fire engine, Rescue Support Vehicle or Aerial Appliance Truck",
+                    "Fire engines, Rescue Support Vehicles or Aerial Appliance Trucks"
+                ],
+                "vehicles": [0, 1, 2, 4, 16, 17, 26, 37, 38, 43, 47]
+            },
+                                    {
+                "texts": [
+                    "Fire engine or Rescue Support Vehicle",
+                    "Fire engines or Rescue Support Vehicles"
+                ],
+                "vehicles": [0, 1, 4, 16, 17, 26, 37, 38, 43, 47]
+            },
             { "texts": ["BASU", "BASUs"], "vehicles": [14, 39, 46, 49] },
             {
                 "texts": ["Water Carrier", "Water Carriers"],

--- a/src/modules/extendedCallWindow/i18n/en_GB.json
+++ b/src/modules/extendedCallWindow/i18n/en_GB.json
@@ -238,7 +238,7 @@
                     "Airfield Operations Vehicle",
                     "Airfield Operations Vehicles"
                 ],
-                "vehicles": [79]
+                "vehicles": [79, 80]
             },
             { "texts": ["RIV", "RIVs"], "vehicles": [76] },
             {

--- a/src/modules/extendedCallWindow/i18n/en_GB.json
+++ b/src/modules/extendedCallWindow/i18n/en_GB.json
@@ -129,6 +129,10 @@
                 "texts": ["Police car", "Police cars"],
                 "vehicles": [8, 12, 13, 19, 24, 25, 51, 52, 56, 82]
             },
+                        {
+                "texts": ["Police Car or Armed Response Vehicle (ARV)", "Police Cars or Armed Response Vehicles (ARVs)"],
+                "vehicles": [8, 12, 13, 19, 24, 25, 51, 52, 56, 82]
+            },
             { "texts": ["HEMS"], "vehicles": [9] },
             {
                 "texts": ["Policehelicopter", "Policehelicopters"],

--- a/src/modules/extendedCallWindow/i18n/en_GB.json
+++ b/src/modules/extendedCallWindow/i18n/en_GB.json
@@ -69,7 +69,7 @@
             },
             {
                 "texts": ["Fire Officer", "Fire Officers"],
-                "vehicles": [3, 15, 44]
+                "vehicles": [3, 15, 44, 77]
             },
             {
                 "texts": [
@@ -101,7 +101,7 @@
                     "ICCU or Ambulance Control Unit",
                     "ICCU or Ambulance Control Units"
                 ],
-                "vehicles": [15, 31, 44]
+                "vehicles": [15, 31, 44, 77]
             },
             {
                 "texts": [
@@ -113,14 +113,14 @@
             { "texts": ["Ambulance", "Ambulances"], "vehicles": [5] },
             {
                 "texts": ["Police car", "Police cars"],
-                "vehicles": [8, 12, 13, 19, 24, 25, 51, 52, 56]
+                "vehicles": [8, 12, 13, 19, 24, 25, 51, 52, 56, 82]
             },
             { "texts": ["HEMS"], "vehicles": [9] },
             {
                 "texts": ["Policehelicopter", "Policehelicopters"],
                 "vehicles": [11]
             },
-            { "texts": ["Armed Response"], "vehicles": [13, 25, 52, 56] },
+            { "texts": ["Armed Response"], "vehicles": [13, 25, 52, 56, 82] },
             {
                 "texts": ["Dog Support Unit (DSU)", "Dog Support Units (DSUs)"],
                 "vehicles": [12, 53]
@@ -158,7 +158,7 @@
             },
             {
                 "texts": ["Foam Unit", "Foam Units"],
-                "vehicles": [35, 36, 37, 38, 42]
+                "vehicles": [35, 36, 37, 38, 42, 75]
             },
             { "texts": ["Mass Casualty Equipment"], "vehicles": [33] },
             { "texts": ["Mounted Unit", "Mounted Units"], "vehicles": [55] },
@@ -225,7 +225,7 @@
                 "texts": ["Major Foam Tender", "Major Foam Tenders"],
                 "vehicles": [75]
             },
-            { "texts": ["Rescue Stair", "Rescue Stairs"], "vehicles": [78] },
+            { "texts": ["Rescue Stair", "Rescue Stairs"], "vehicles": [78, 2, 17] },
             {
                 "texts": [
                     "Airfield Firefighting Command Vehicle",

--- a/src/modules/extendedCallWindow/i18n/en_GB.json
+++ b/src/modules/extendedCallWindow/i18n/en_GB.json
@@ -186,7 +186,7 @@
                 ],
                 "vehicles": [67, 74]
             },
-            { "texts": ["ILB", "ILBs"], "vehicles": [68] },
+            { "texts": ["ILB or ALB", "ILBs or ALBs"], "vehicles": [68, 69] },
             {
                 "texts": [
                     "Coastguard Rescue Helicopter",


### PR DESCRIPTION
Fixed  Numerous Missing Vehicles.

<!-- Please start the title of this PR with 🔀 -->

<!-- Note: Please stick to this template to help us keep LSSM clean! -->
**What kind of update does this PR provide?** *Please check*
<!-- you can check a checkbox by replacing the space ` ` with a `x`: [x] -->
- [ ] new translations / updated translations / translation fixes
- [ ] a new feature
- [ ] a new module
- [x] a bugfix for an existing feature / module
- [ ] improvement of style or user experience
- [ ] other: *Please fill out*



**What is included in your update?**
* fixed airport command unit not counting as fire officer & ICCU in ecw, despite them counting ingame
* fixed Armed Cell Van to act as a Police Car & ARV
* fixed Aerial Appliance & CARP to Rescue Stairs, as they can be replaced.
* Added Airport Supervisor Unit as Airport Operations Vehicle
* added Engine or RSU or ALP & Engine or RSU to ecw
* added police car or arv (despite this being relatively obsolete as ever firearms unit already counts as a police car, but devs love copy and pasting!)
* fix ILB to include the ALB and update the translation to changes made by devs
* add Coastguard Rope & Mud Rescue as a CRV

**Additional notes**
Please add any further notes here!
