### PR TITLE
Seenotrettungsschule zu Schulen verschoben

### DIFF
--- a/src/modules/buildingListFilter/i18n/de_DE.root.json
+++ b/src/modules/buildingListFilter/i18n/de_DE.root.json
@@ -5,14 +5,14 @@
         { "ids": [6, 19], "name": "Polizei" },
         { "ids": [9], "name": "THW" },
         { "ids": [15], "name": "Wasserrettung" },
-        { "ids": [1, 3, 8, 10], "name": "Schulen" },
+        { "ids": [1, 3, 8, 10, 27], "name": "Schulen" },
         { "ids": [7], "name": "Leitstelle" },
         { "ids": [5, 12, 21, 25], "name": "SEG/RTH" },
         { "ids": [11, 24], "name": "Bepol" },
         { "ids": [13, 17], "name": "PolHeli/Pol-Sonder" },
         { "ids": [4], "name": "Krankenhäuser" },
         { "ids": [22, 23], "name": "Komplexe" },
-        { "ids": [26, 27, 28], "name": "Seenotrettung" }
+        { "ids": [26, 28], "name": "Seenotrettung" }
     ],
     "description": "Passe dir die Filter der Gebäudeliste frei an!",
     "lssmComplex": "LSSM Gebäudekomplex",


### PR DESCRIPTION
**What kind of update does this PR provide?** *Please check*
<!-- you can check a checkbox by replacing the space ` ` with a `x`: [x] -->
- [ ] new translations / updated translations / translation fixes
- [ ] a new feature
- [ ] a new module
- [x] a bugfix for an existing feature / module
- [ ] improvement of style or user experience
- [ ] other: *Please fill out*

**What is included in your update?**
* moved the "Schule für Seefahrt und Seenotrettung" to the tab "Schulen" in default german

ISSUE: #3555