### PR TITLE
🔀 Add optional monospaced font for notes

### DIFF
--- a/src/modules/generalExtensions/assets/noteMonospace.ts
+++ b/src/modules/generalExtensions/assets/noteMonospace.ts
@@ -1,0 +1,23 @@
+export default (LSSM: Vue): void => {
+    const redesignNoteId = LSSM.$stores.root.nodeAttribute(
+        'redesign-note-message',
+        true
+    );
+    const redesignNotePreviewId = LSSM.$stores.root.nodeAttribute(
+        'redesign-note-message_preview',
+        true
+    );
+
+    LSSM.$stores.root.addStyle({
+        selectorText: [
+            'textarea[name="note[message]"]',
+            '#note-message',
+            '#note_message',
+            `#${redesignNoteId}`,
+            `#${redesignNotePreviewId}`,
+        ].join(','),
+        style: {
+            'font-family': 'monospace',
+        },
+    });
+};

--- a/src/modules/generalExtensions/docs/en_GB.md
+++ b/src/modules/generalExtensions/docs/en_GB.md
@@ -40,6 +40,10 @@ This feature is still under development - Therefore there is no photo yet.
 This feature is still under development - Therefore there is no photo yet.
 :::
 
+## Monospaced Notes
+
+Displays the notes editor in a fixed-width font so that tables, columns, and aligned text remain easy to read.
+
 ## Save Map Jumps
 
 ::: warning Map Type "Mapkit"

--- a/src/modules/generalExtensions/i18n/cs_CZ.root.json
+++ b/src/modules/generalExtensions/i18n/cs_CZ.root.json
@@ -48,6 +48,10 @@
             "description": "Vycentruje mapu na předchozí pozice, na které byla dříve vycentrována. – Funkční pouze pro typ mapy \"OpenStreetMap\"",
             "title": "Uložení pohybů mapy"
         },
+        "noteMonospace": {
+            "description": "Zobrazí poznámky písmem s pevnou šířkou, aby byly tabulky a zarovnaný text lépe čitelné.",
+            "title": "Poznámky neproporcionálním písmem"
+        },
         "notePreview": {
             "description": "Na odkazy v poznámkách lze kliknout zobrazením náhledu poznámek.",
             "title": "Poznámky"

--- a/src/modules/generalExtensions/i18n/de_DE.root.json
+++ b/src/modules/generalExtensions/i18n/de_DE.root.json
@@ -48,6 +48,10 @@
             "description": "Zentriere Karte auf Positionen, auf die vorher zentriert wurde. – Funktioniert aktuell nur beim Kartentyp \"OpenStreetMap\"",
             "title": "Kartensprünge speichern"
         },
+        "noteMonospace": {
+            "description": "Zeigt Notizen in einer Schrift mit fester Zeichenbreite an, damit Tabellen und ausgerichteter Text leichter lesbar sind.",
+            "title": "Notizen in Festbreitenschrift"
+        },
         "notePreview": {
             "description": "Macht Links in den Notizen anklickbar, indem eine Vorschau der Notizen angezeigt wird.",
             "title": "Notizen"

--- a/src/modules/generalExtensions/i18n/en_AU.root.json
+++ b/src/modules/generalExtensions/i18n/en_AU.root.json
@@ -48,6 +48,10 @@
             "description": "Center map on positions that were centered before. - Currently only works with map type \"OpenStreetMap\"",
             "title": "Save map jumps"
         },
+        "noteMonospace": {
+            "description": "Displays notes in a monospaced font to make tables and aligned text easier to read.",
+            "title": "Monospaced notes"
+        },
         "notePreview": {
             "description": "Links in notes are made clickable by displaying a preview of the notes.",
             "title": "Notes"

--- a/src/modules/generalExtensions/i18n/en_GB.root.json
+++ b/src/modules/generalExtensions/i18n/en_GB.root.json
@@ -48,6 +48,10 @@
             "description": "Center map on positions that were centered before. - Currently only works with map type \"OpenStreetMap\"",
             "title": "Save map jumps"
         },
+        "noteMonospace": {
+            "description": "Displays notes in a monospaced font to make tables and aligned text easier to read.",
+            "title": "Monospaced notes"
+        },
         "notePreview": {
             "description": "Links in notes are made clickable by displaying a preview of the notes.",
             "title": "Notes"

--- a/src/modules/generalExtensions/i18n/en_US.root.json
+++ b/src/modules/generalExtensions/i18n/en_US.root.json
@@ -48,6 +48,10 @@
             "description": "Center map on positions that were centered before. - Currently only works with map type \"OpenStreetMap\"",
             "title": "Save map jumps"
         },
+        "noteMonospace": {
+            "description": "Displays notes in a monospaced font to make tables and aligned text easier to read.",
+            "title": "Monospaced notes"
+        },
         "notePreview": {
             "description": "Links in notes are made clickable by displaying a preview of the notes.",
             "title": "Notes"

--- a/src/modules/generalExtensions/i18n/fi_FI.root.json
+++ b/src/modules/generalExtensions/i18n/fi_FI.root.json
@@ -48,6 +48,10 @@
             "description": "Keskitä kartta sijainteihin, jotka oli keskitetty aiemmin. - Tällä hetkellä toimii vain karttatyypin \"OpenStreetMap\" kanssa.",
             "title": "Tallenna karttahyppyjä"
         },
+        "noteMonospace": {
+            "description": "Näyttää muistiinpanot tasalevyisellä fontilla, jotta taulukot ja tasattu teksti ovat helpommin luettavia.",
+            "title": "Tasalevyiset muistiinpanot"
+        },
         "notePreview": {
             "description": "Muistiinpanoissa olevia linkkejä voi napsauttaa näyttämällä muistiinpanojen esikatselun.",
             "title": "Muistiinpanot"

--- a/src/modules/generalExtensions/i18n/fr_FR.root.json
+++ b/src/modules/generalExtensions/i18n/fr_FR.root.json
@@ -48,6 +48,10 @@
             "description": "Centre la carte sur la position du dernier centrage. Ne marche qu'avec \"OpenStreetMap\" pour le moment.",
             "title": "Enregistrer le centrage de la carte"
         },
+        "noteMonospace": {
+            "description": "Affiche les notes avec une police à chasse fixe afin de faciliter la lecture des tableaux et du texte aligné.",
+            "title": "Notes en police monospace"
+        },
         "notePreview": {
             "description": "Les liens dans les notes sont rendus cliquables en affichant un aperçu des notes.",
             "title": "Notes"

--- a/src/modules/generalExtensions/i18n/nl_NL.root.json
+++ b/src/modules/generalExtensions/i18n/nl_NL.root.json
@@ -47,6 +47,10 @@
             "description": "Kaart centreren op posities die eerder waren gecentreerd. - Werkt momenteel alleen met het kaarttype \"OpenStreetMap\"",
             "title": "Bewaar kaart verplaatsingen"
         },
+        "noteMonospace": {
+            "description": "Toont notities in een lettertype met vaste tekenbreedte, zodat tabellen en uitgelijnde tekst gemakkelijker leesbaar zijn.",
+            "title": "Notities in monospace"
+        },
         "notePreview": {
             "description": "Links in notities worden klikbaar gemaakt door een voorvertoning van de notitie te tonen.",
             "title": "Notities"

--- a/src/modules/generalExtensions/i18n/pl_PL.root.json
+++ b/src/modules/generalExtensions/i18n/pl_PL.root.json
@@ -48,6 +48,10 @@
             "description": "Zapisuje poprzednio wybrane pozycje mapy, tak abyś mógł do nich wrócić jednym kliknięciem. - Obecnie działa tylko z mapą typu \"OpenStreetMap\"",
             "title": "Skoki mapy"
         },
+        "noteMonospace": {
+            "description": "Wyświetla notatki czcionką o stałej szerokości, aby tabele i wyrównany tekst były łatwiejsze do odczytania.",
+            "title": "Notatki czcionką monospace"
+        },
         "notePreview": {
             "description": "Linki w notatkach stają się klikalne.",
             "title": "Linki w notatkach"

--- a/src/modules/generalExtensions/i18n/sv_SE.root.json
+++ b/src/modules/generalExtensions/i18n/sv_SE.root.json
@@ -49,6 +49,10 @@
             "description": "Centrera kartan på positioner som var centrerade tidigare. - Fungerar för närvarande bara med karttyp \"OpenStreetMap\"",
             "title": "Spara karthopp"
         },
+        "noteMonospace": {
+            "description": "Visar anteckningar med ett typsnitt med fast teckenbredd så att tabeller och justerad text blir lättare att läsa.",
+            "title": "Anteckningar med fast teckenbredd"
+        },
         "notePreview": {
             "description": "Länkar i anteckning görs klickbara gemom att förhandsgranska anteckningen.",
             "title": "Anteckningar"

--- a/src/modules/generalExtensions/main.ts
+++ b/src/modules/generalExtensions/main.ts
@@ -28,6 +28,13 @@ export default (async ({ LSSM, MODULE_ID, $m, getSetting, setSetting }) => {
             clickableLinks(LSSM, await getSetting('showImg'))
         );
     }
+
+    if (await getSetting<boolean>('noteMonospace')) {
+        import(
+            /* webpackChunkName: "modules/generalExtensions/noteMonospace" */ './assets/noteMonospace'
+        ).then(({ default: noteMonospace }) => noteMonospace(LSSM));
+    }
+
     const linkPreviewSetting = await getSetting<string[]>('linkPreviews');
     if (linkPreviewSetting.length) {
         import(

--- a/src/modules/generalExtensions/settings.ts
+++ b/src/modules/generalExtensions/settings.ts
@@ -18,6 +18,10 @@ export default ((_, __, $m) => {
             default: true,
             dependsOn: '.clickableLinks',
         },
+        noteMonospace: <Toggle>{
+            type: 'toggle',
+            default: false,
+        },
         linkPreviews: <Omit<MultiSelect, 'isDisabled' | 'value'>>{
             type: 'multiSelect',
             default: [],


### PR DESCRIPTION
**What kind of update does this PR provide?** *Please check*

- [ ] new translations / updated translations / translation fixes
- [x] a new feature
- [ ] a new module
- [ ] a bugfix for an existing feature / module
- [x] improvement of style or user experience
- [ ] other: *Please fill out*

<!-- If PR contains translations -->
**Which language(s) did you add/update translations for?**
*use the xx_XX notation for exact language!*

* cs_CZ
* de_DE
* en_AU
* en_GB
* en_US
* fi_FI
* fr_FR
* nl_NL
* pl_PL
* sv_SE

<!-- END IF translations -->

**What is included in your update?**

* Added an optional `noteMonospace` setting to General improvements.
* Added monospaced styling for the native note editor.
* Added support for the redesigned note editor and note preview.
* Added localisation entries for the existing supported locale files.
* Updated the English module documentation.
* The setting is disabled by default.
* Unrelated inputs and textareas are not affected.

**Additional notes**

Implements the feature requested in #2906.

The branch contains one clean feature commit based on the current `dev` branch.

Translations may be adjusted by maintainers or native speakers if required.

Closes #2906