### PR TITLE
🔀 Add alliance member list role filters

### DIFF
--- a/src/modules/allianceMemberList/assets/memberList.ts
+++ b/src/modules/allianceMemberList/assets/memberList.ts
@@ -1,0 +1,378 @@
+import type { $m } from 'typings/Module';
+
+type ActivityState =
+    | 'blue'
+    | 'gray'
+    | 'green'
+    | 'red'
+    | 'unknown'
+    | 'yellow';
+
+type SortType = 'activity' | 'default' | 'name' | 'role';
+
+interface Member {
+    activity: ActivityState;
+    id: string;
+    name: string;
+    order: number;
+    roles: string[];
+    row: HTMLTableRowElement;
+}
+
+const NO_ROLE = '__lssm_no_role__';
+
+const findMemberTable = (doc: Document): HTMLTableElement | null =>
+    Array.from(doc.querySelectorAll<HTMLTableElement>('table')).find(table =>
+        table.querySelector('tbody a[href^="/profile/"]')
+    ) ?? null;
+
+const getMemberBody = (table: HTMLTableElement): HTMLTableSectionElement | null =>
+    Array.from(table.tBodies).at(-1) ?? null;
+
+const getLastPage = (doc: Document): number => {
+    const penultimateItem = doc.querySelector<HTMLElement>(
+        '.pagination.pagination li:nth-last-of-type(2)'
+    );
+    const lastPage = Number.parseInt(
+        penultimateItem?.textContent?.trim() ?? '1'
+    );
+
+    if (Number.isFinite(lastPage) && lastPage > 0) return lastPage;
+
+    const pageNumbers = Array.from(
+        doc.querySelectorAll<HTMLAnchorElement>('.pagination a')
+    )
+        .map(link => Number.parseInt(link.textContent?.trim() ?? '0'))
+        .filter(Number.isFinite);
+
+    return Math.max(1, ...pageNumbers);
+};
+
+const getActivity = (row: HTMLTableRowElement): ActivityState =>
+    (row
+        .querySelector<HTMLImageElement>('img.online_icon')
+        ?.src.match(/user_(?<activity>blue|gray|green|red|yellow)\.png/u)?.groups
+        ?.activity as ActivityState | undefined) ?? 'unknown';
+
+const getRoles = (row: HTMLTableRowElement): string[] =>
+    (row.cells.item(1)?.querySelector('small')?.textContent ?? '')
+        .split(',')
+        .map(role => role.trim())
+        .filter(Boolean)
+        .sort((a, b) => a.localeCompare(b));
+
+const parseMember = (
+    row: HTMLTableRowElement,
+    page: number,
+    index: number
+): Member | null => {
+    const profile = row.querySelector<HTMLAnchorElement>('a[href^="/profile/"]');
+    if (!profile) return null;
+
+    const { pathname, textContent } = profile;
+    const name = textContent?.trim() ?? '';
+    if (!name) return null;
+
+    return {
+        activity: getActivity(row),
+        id:
+            pathname.match(/^\/profile\/(?<id>\d+)/u)?.groups?.id ??
+            pathname,
+        name,
+        order: page * 10_000 + index,
+        roles: getRoles(row),
+        row,
+    };
+};
+
+const createOption = (value: string, text: string): HTMLOptionElement => {
+    const option = document.createElement('option');
+    option.value = value;
+    option.textContent = text;
+    return option;
+};
+
+export default (LSSM: Vue, $m: $m, MODULE_ID: string): void => {
+    const table = findMemberTable(document);
+    const tbody = table && getMemberBody(table);
+    if (
+        !table ||
+        !tbody ||
+        document.getElementById(`${MODULE_ID}-controls`)
+    )
+        return;
+
+    const currentUrl = new URL(window.location.href);
+    const pageFromUrl = Number.parseInt(
+        currentUrl.searchParams.get('page') ?? '1'
+    );
+    const currentPage =
+        Number.isFinite(pageFromUrl) && pageFromUrl > 0 ? pageFromUrl : 1;
+    const totalPages = getLastPage(document);
+    const pagination = document.querySelector<HTMLElement>(
+        '.pagination.pagination'
+    );
+    const loadedPages = new Set<number>([currentPage]);
+    const members = new Map<string, Member>();
+    const collator = new Intl.Collator(undefined, {
+        numeric: true,
+        sensitivity: 'base',
+    });
+
+    Array.from(tbody.rows).forEach((row, index) => {
+        const member = parseMember(row, currentPage, index);
+        if (member) members.set(member.id, member);
+    });
+
+    if (!members.size) return;
+
+    const controls = document.createElement('div');
+    controls.id = `${MODULE_ID}-controls`;
+    controls.classList.add('panel', 'panel-default');
+
+    const panelBody = document.createElement('div');
+    panelBody.classList.add('panel-body');
+    controls.append(panelBody);
+
+    const form = document.createElement('div');
+    form.classList.add('form-inline');
+    panelBody.append(form);
+
+    const appendSpacer = () => form.append(document.createTextNode(' '));
+
+    const createSelectGroup = (labelText: string) => {
+        const group = document.createElement('div');
+        group.classList.add('form-group');
+
+        const label = document.createElement('label');
+        label.textContent = `${labelText} `;
+
+        const select = document.createElement('select');
+        select.classList.add('form-control', 'input-sm');
+        label.append(select);
+        group.append(label);
+        form.append(group);
+        appendSpacer();
+
+        return select;
+    };
+
+    const roleSelect = createSelectGroup($m('role').toString());
+    const activitySelect = createSelectGroup($m('activity').toString());
+    const sortSelect = createSelectGroup($m('sort').toString());
+
+    activitySelect.append(
+        createOption('', $m('allActivities').toString()),
+        createOption('online', $m('online').toString()),
+        createOption('offline', $m('offline').toString())
+    );
+
+    sortSelect.append(
+        createOption('default', $m('sortOptions.default').toString()),
+        createOption('name', $m('sortOptions.name').toString()),
+        createOption('role', $m('sortOptions.role').toString()),
+        createOption('activity', $m('sortOptions.activity').toString())
+    );
+
+    const directionButton = document.createElement('button');
+    const directionTitle = $m('direction').toString();
+    directionButton.type = 'button';
+    directionButton.classList.add('btn', 'btn-default', 'btn-sm');
+    directionButton.textContent = '↑';
+    directionButton.title = directionTitle;
+    directionButton.setAttribute('aria-label', directionTitle);
+    directionButton.setAttribute('aria-pressed', 'false');
+    form.append(directionButton);
+    appendSpacer();
+
+    const loadAllButton = document.createElement('button');
+    loadAllButton.type = 'button';
+    loadAllButton.classList.add('btn', 'btn-primary', 'btn-sm');
+    loadAllButton.textContent =
+        totalPages <= 1
+            ? $m('allLoaded').toString()
+            : $m('loadAll').toString();
+    loadAllButton.disabled = totalPages <= 1;
+    form.append(loadAllButton);
+    appendSpacer();
+
+    const resetButton = document.createElement('button');
+    resetButton.type = 'button';
+    resetButton.classList.add('btn', 'btn-default', 'btn-sm');
+    resetButton.textContent = $m('reset').toString();
+    form.append(resetButton);
+
+    const progress = document.createElement('p');
+    progress.classList.add('help-block');
+    progress.setAttribute('aria-live', 'polite');
+    panelBody.append(progress);
+
+    const summary = document.createElement('p');
+    summary.classList.add('help-block');
+    summary.setAttribute('aria-live', 'polite');
+    panelBody.append(summary);
+
+    table.before(controls);
+
+    let descending = false;
+
+    const refreshRoleOptions = () => {
+        const selectedRole = roleSelect.value;
+        const roles = Array.from(
+            new Set(Array.from(members.values()).flatMap(member => member.roles))
+        ).sort((a, b) => collator.compare(a, b));
+
+        roleSelect.replaceChildren(
+            createOption('', $m('allRoles').toString()),
+            createOption(NO_ROLE, $m('noRole').toString()),
+            ...roles.map(role => createOption(role, role))
+        );
+
+        if (
+            Array.from(roleSelect.options).some(
+                ({ value }) => value === selectedRole
+            )
+        )
+            roleSelect.value = selectedRole;
+    };
+
+    const activityRank: Record<ActivityState, number> = {
+        green: 0,
+        gray: 1,
+        blue: 2,
+        yellow: 3,
+        red: 4,
+        unknown: 5,
+    };
+
+    const apply = () => {
+        const selectedRole = roleSelect.value;
+        const selectedActivity = activitySelect.value;
+        const sort = sortSelect.value as SortType;
+        const modifier = descending ? -1 : 1;
+        const sortedMembers = Array.from(members.values()).sort((a, b) => {
+            let comparison = 0;
+
+            if (sort === 'name') comparison = collator.compare(a.name, b.name);
+            else if (sort === 'role') {
+                const aRoles = a.roles.join(', ');
+                const bRoles = b.roles.join(', ');
+                comparison = collator.compare(
+                    aRoles || '\uffff',
+                    bRoles || '\uffff'
+                );
+            } else if (sort === 'activity') {
+                comparison = activityRank[a.activity] - activityRank[b.activity];
+            } else comparison = a.order - b.order;
+
+            if (!comparison) comparison = collator.compare(a.name, b.name);
+            return comparison * modifier;
+        });
+
+        let visible = 0;
+        sortedMembers.forEach(member => {
+            const roleMatches =
+                !selectedRole ||
+                (selectedRole === NO_ROLE
+                    ? !member.roles.length
+                    : member.roles.includes(selectedRole));
+            const activityMatches =
+                !selectedActivity ||
+                (selectedActivity === 'online'
+                    ? member.activity === 'green'
+                    : member.activity !== 'green' &&
+                      member.activity !== 'unknown');
+
+            member.row.hidden = !(roleMatches && activityMatches);
+            if (!member.row.hidden) visible++;
+            tbody.append(member.row);
+        });
+
+        summary.textContent = $m('summary', {
+            loadedPages: loadedPages.size,
+            total: members.size,
+            totalPages,
+            visible,
+        }).toString();
+    };
+
+    const addPage = (doc: Document, page: number) => {
+        const pageTable = findMemberTable(doc);
+        const pageBody = pageTable && getMemberBody(pageTable);
+        if (!pageBody) throw new Error(`Member table missing on page ${page}`);
+
+        Array.from(pageBody.rows).forEach((row, index) => {
+            const importedRow = document.importNode(row, true);
+            const member = parseMember(importedRow, page, index);
+            if (!member || members.has(member.id)) return;
+            members.set(member.id, member);
+            tbody.append(importedRow);
+        });
+        loadedPages.add(page);
+        refreshRoleOptions();
+        apply();
+    };
+
+    roleSelect.addEventListener('change', apply);
+    activitySelect.addEventListener('change', apply);
+    sortSelect.addEventListener('change', apply);
+    directionButton.addEventListener('click', () => {
+        descending = !descending;
+        directionButton.textContent = descending ? '↓' : '↑';
+        directionButton.setAttribute('aria-pressed', descending.toString());
+        apply();
+    });
+    resetButton.addEventListener('click', () => {
+        roleSelect.value = '';
+        activitySelect.value = '';
+        sortSelect.value = 'default';
+        descending = false;
+        directionButton.textContent = '↑';
+        directionButton.setAttribute('aria-pressed', 'false');
+        apply();
+    });
+    loadAllButton.addEventListener('click', async () => {
+        loadAllButton.disabled = true;
+
+        const pages = Array.from(
+            { length: totalPages },
+            (_, index) => index + 1
+        );
+        for (const page of pages) {
+            if (loadedPages.has(page)) continue;
+
+            progress.textContent = $m('loading', { page, totalPages }).toString();
+            const pageUrl = new URL(currentUrl);
+            pageUrl.searchParams.set('page', page.toString());
+
+            try {
+                const response = await LSSM.$stores.api.request(
+                    pageUrl,
+                    `${MODULE_ID}-page-${page}`
+                );
+                const { ok, status } = response;
+                if (!ok) throw new Error(`HTTP ${status}`);
+
+                const html = await response.text();
+                addPage(
+                    new DOMParser().parseFromString(html, 'text/html'),
+                    page
+                );
+            } catch (error) {
+                LSSM.$stores.console.error(
+                    `Alliance member list: ${String(error)}`
+                );
+                progress.textContent = $m('loadError', { page }).toString();
+                loadAllButton.disabled = false;
+                return;
+            }
+        }
+
+        progress.textContent = $m('allLoaded').toString();
+        loadAllButton.textContent = $m('allLoaded').toString();
+        if (pagination) pagination.hidden = true;
+    });
+
+    refreshRoleOptions();
+    apply();
+};

--- a/src/modules/allianceMemberList/docs/de_DE.md
+++ b/src/modules/allianceMemberList/docs/de_DE.md
@@ -1,0 +1,15 @@
+# Verbands-Mitgliederliste
+
+Dieses Modul erweitert die Verbands-Mitgliederliste um lokale Sortierungen sowie Filter für Rollen und Aktivität.
+
+## Verwendung
+
+1. Öffne die Verbands-Mitgliederliste.
+2. Wähle **Alle Mitgliederseiten laden**, um die vollständige, paginierte Liste zusammenzuführen.
+3. Filtere Mitglieder nach Rolle oder Online-Status oder sortiere die zusammengeführte Liste nach Name, Rolle oder Aktivität.
+
+Das vorhandene farbige Aktivitätssymbol bleibt bei jedem Mitglied sichtbar. Das Modul wertet das grüne Symbol als online und die übrigen bekannten Symbolfarben als offline.
+
+::: warning Anfragen
+Beim Laden der vollständigen Liste wird für jede noch nicht geladene Mitgliederseite eine authentifizierte Anfrage an dieselbe Domain gesendet. Die Seiten werden nacheinander geladen, damit keine große Anzahl gleichzeitiger Anfragen an den Spielserver gesendet wird.
+:::

--- a/src/modules/allianceMemberList/docs/en_GB.md
+++ b/src/modules/allianceMemberList/docs/en_GB.md
@@ -1,0 +1,15 @@
+# Alliance member list
+
+This module enhances the alliance member list with local sorting and filters for member roles and activity.
+
+## Usage
+
+1. Open the alliance member list.
+2. Select **Load all member pages** to combine the complete paginated list.
+3. Filter members by role or online state, or sort the combined list by name, role, or activity.
+
+The existing coloured activity icon remains visible for every member. The module treats the green icon as online and the remaining known icon colours as offline.
+
+::: warning Requests
+Loading the complete list performs one authenticated, same-origin request for each remaining member page. Pages are loaded sequentially to avoid sending a burst of requests to the game server.
+:::

--- a/src/modules/allianceMemberList/i18n/de_DE.root.json
+++ b/src/modules/allianceMemberList/i18n/de_DE.root.json
@@ -1,0 +1,25 @@
+{
+    "activity": "Aktivität",
+    "allActivities": "Alle Aktivitätsstatus",
+    "allLoaded": "Alle Mitgliederseiten wurden geladen",
+    "allRoles": "Alle Rollen",
+    "description": "Lädt die vollständige Verbands-Mitgliederliste und ergänzt Rollen- und Aktivitätsfilter mit lokaler Sortierung.",
+    "direction": "Sortierreihenfolge umkehren",
+    "loadAll": "Alle Mitgliederseiten laden",
+    "loadError": "Seite {page} konnte nicht geladen werden. Die übrigen Seiten können erneut geladen werden.",
+    "loading": "Mitgliederseite {page} von {totalPages} wird geladen…",
+    "name": "Verbands-Mitgliederliste",
+    "noRole": "Keine Rolle",
+    "offline": "Offline",
+    "online": "Online",
+    "reset": "Zurücksetzen",
+    "role": "Rolle",
+    "sort": "Sortieren nach",
+    "sortOptions": {
+        "activity": "Aktivität",
+        "default": "Ursprüngliche Reihenfolge",
+        "name": "Name",
+        "role": "Rolle"
+    },
+    "summary": "{visible} von {total} Mitgliedern werden angezeigt · {loadedPages}/{totalPages} Seiten geladen"
+}

--- a/src/modules/allianceMemberList/i18n/en_AU.root.json
+++ b/src/modules/allianceMemberList/i18n/en_AU.root.json
@@ -1,0 +1,25 @@
+{
+    "activity": "Activity",
+    "allActivities": "All activity states",
+    "allLoaded": "All member pages loaded",
+    "allRoles": "All roles",
+    "description": "Loads the complete alliance member list and adds role and activity filters with local sorting.",
+    "direction": "Reverse sort direction",
+    "loadAll": "Load all member pages",
+    "loadError": "Page {page} could not be loaded. You can retry the remaining pages.",
+    "loading": "Loading member page {page} of {totalPages}…",
+    "name": "Alliance member list",
+    "noRole": "No role",
+    "offline": "Offline",
+    "online": "Online",
+    "reset": "Reset",
+    "role": "Role",
+    "sort": "Sort by",
+    "sortOptions": {
+        "activity": "Activity",
+        "default": "Original order",
+        "name": "Name",
+        "role": "Role"
+    },
+    "summary": "Showing {visible} of {total} members · {loadedPages}/{totalPages} pages loaded"
+}

--- a/src/modules/allianceMemberList/i18n/en_GB.root.json
+++ b/src/modules/allianceMemberList/i18n/en_GB.root.json
@@ -1,0 +1,25 @@
+{
+    "activity": "Activity",
+    "allActivities": "All activity states",
+    "allLoaded": "All member pages loaded",
+    "allRoles": "All roles",
+    "description": "Loads the complete alliance member list and adds role and activity filters with local sorting.",
+    "direction": "Reverse sort direction",
+    "loadAll": "Load all member pages",
+    "loadError": "Page {page} could not be loaded. You can retry the remaining pages.",
+    "loading": "Loading member page {page} of {totalPages}…",
+    "name": "Alliance member list",
+    "noRole": "No role",
+    "offline": "Offline",
+    "online": "Online",
+    "reset": "Reset",
+    "role": "Role",
+    "sort": "Sort by",
+    "sortOptions": {
+        "activity": "Activity",
+        "default": "Original order",
+        "name": "Name",
+        "role": "Role"
+    },
+    "summary": "Showing {visible} of {total} members · {loadedPages}/{totalPages} pages loaded"
+}

--- a/src/modules/allianceMemberList/i18n/en_US.root.json
+++ b/src/modules/allianceMemberList/i18n/en_US.root.json
@@ -1,0 +1,25 @@
+{
+    "activity": "Activity",
+    "allActivities": "All activity states",
+    "allLoaded": "All member pages loaded",
+    "allRoles": "All roles",
+    "description": "Loads the complete alliance member list and adds role and activity filters with local sorting.",
+    "direction": "Reverse sort direction",
+    "loadAll": "Load all member pages",
+    "loadError": "Page {page} could not be loaded. You can retry the remaining pages.",
+    "loading": "Loading member page {page} of {totalPages}…",
+    "name": "Alliance member list",
+    "noRole": "No role",
+    "offline": "Offline",
+    "online": "Online",
+    "reset": "Reset",
+    "role": "Role",
+    "sort": "Sort by",
+    "sortOptions": {
+        "activity": "Activity",
+        "default": "Original order",
+        "name": "Name",
+        "role": "Role"
+    },
+    "summary": "Showing {visible} of {total} members · {loadedPages}/{totalPages} pages loaded"
+}

--- a/src/modules/allianceMemberList/main.ts
+++ b/src/modules/allianceMemberList/main.ts
@@ -1,0 +1,10 @@
+import type { ModuleMainFunction } from 'typings/Module';
+
+export default (async ({ LSSM, MODULE_ID, $m }) => {
+    if (!/^\/verband\/mitglieder(?:\/\d+)?\/?$/u.test(window.location.pathname))
+        return;
+
+    import(
+        /* webpackChunkName: "modules/allianceMemberList/memberList" */ './assets/memberList'
+    ).then(({ default: memberList }) => memberList(LSSM, $m, MODULE_ID));
+}) as ModuleMainFunction;

--- a/src/modules/allianceMemberList/register.json
+++ b/src/modules/allianceMemberList/register.json
@@ -1,0 +1,6 @@
+{
+    "dev": true,
+    "github": 2271,
+    "locales": ["de_DE", "en_AU", "en_GB", "en_US"],
+    "location": "^/verband/mitglieder(?:/\\d+)?/?$"
+}


### PR DESCRIPTION
**What kind of update does this PR provide?** *Please check*

- [x] new translations / updated translations / translation fixes
- [x] a new feature
- [x] a new module
- [ ] a bugfix for an existing feature / module
- [x] improvement of style or user experience
- [ ] other: *Please fill out*

<!-- If PR contains translations -->
**Which language(s) did you add/update translations for?**
*use the xx_XX notation for exact language!*

* de_DE
* en_AU
* en_GB
* en_US

<!-- END IF translations -->

**What is included in your update?**

* Adds a new Alliance member list module for `/verband/mitglieder`.
* Adds an option to load all remaining paginated member-list pages.
* Loads pages sequentially to avoid sending excessive simultaneous requests.
* Combines and de-duplicates members from all loaded pages.
* Adds filtering by Alliance role.
* Adds filtering by online or offline activity state.
* Adds sorting by original order, member name, role, or activity state.
* Adds ascending and descending sorting.
* Preserves existing profile links and Alliance administration controls.
* Adds German and English documentation.
* Adds translations for `de_DE`, `en_AU`, `en_GB`, and `en_US`.

**Additional notes**

Implements the feature requested in #2271.

Activity information is derived from the existing online-status icons provided by the game. This PR does not add historical activity tracking.

Additional member pages are only fetched when the user selects **Load all member pages**.

The module is registered as a development module and is disabled unless enabled through the LSSM App Store.

The branch contains one clean feature commit based on the current `dev` branch.

Closes #2271