### PR TITLE
🔀🌐 [sv_SE] add translations for extendedMap

### DIFF
--- a/src/modules/extendedMap/i18n/sv_SE.json
+++ b/src/modules/extendedMap/i18n/sv_SE.json
@@ -1,0 +1,136 @@
+{
+    "buildingComplexes": {
+        "buildingList": { "details": "Detaljer" },
+        "new": "Nytt LSSM-byggnadskomplex",
+        "openInLightbox": "Öppna byggnad i Lightbox",
+        "overview": {
+            "buildings": {
+                "hiring": {
+                    "automatic": "automatiskt",
+                    "no": "Ingen",
+                    "phase": "1 dag | {n} dagar"
+                },
+                "inConstruction": "varav {n} under uppbyggnad",
+                "share": {
+                    "beds": {
+                        "share": "Dela sängar med alliansen",
+                        "unShare": "Dela inte sängar med alliansen"
+                    },
+                    "cells": {
+                        "share": "Dela fängelseceller med alliansen",
+                        "unShare": "Dela inte fängelseceller med alliansen"
+                    }
+                },
+                "table": {
+                    "alliance": "Alliansen",
+                    "head": {
+                        "beds": "Sängar",
+                        "cells": "Celler",
+                        "classrooms": "Klassrum",
+                        "hiring": "Anställningsfas",
+                        "level": "Nivå",
+                        "name": "Namn",
+                        "staff": "Personal (personalmål)",
+                        "vehicles": "Fordon"
+                    }
+                },
+                "title": "anslutna byggnader"
+            },
+            "classrooms": {
+                "startTraining": "Starta en ny utbildning",
+                "subtitle": "{total} totalt, varav {unavailable} under uppbyggnad och {free} lediga",
+                "table": {
+                    "countdown": "återstående tid",
+                    "free": "Lediga platser",
+                    "freeClassrooms": "1 ledigt klassrum|{n} lediga klassrum",
+                    "running": {
+                        "false": "Nej",
+                        "title": "pågår?",
+                        "true": "Ja"
+                    },
+                    "start": "starta ny utbildningskurs",
+                    "unavailable": "1 klassrum under uppbyggnad|{n} klassrum under uppbyggnad"
+                },
+                "title": "Klassrum"
+            },
+            "extensions": {
+                "abort": "Avbryt",
+                "allianceFunds": "betalat med allianspengar",
+                "disable": "inaktivera",
+                "disabled": "Klar & inaktiverad",
+                "enable": "aktivera",
+                "enabled": "Klar & aktiverad",
+                "filter": {
+                    "all": "Alla",
+                    "buildings": "Byggnader",
+                    "canBuy": "kan köpas",
+                    "cannotBuy": "kan inte köpas",
+                    "cannotToggle": "kan inte aktiveras/inaktiveras",
+                    "canToggle": "kan aktiveras/inaktiveras",
+                    "disabled": "klar & inaktiverad",
+                    "enabled": "klar & aktiverad",
+                    "extensions": "Utbyggnader",
+                    "states": "Status",
+                    "underConstruction": "under uppbyggnad"
+                },
+                "limit": "Du kan för närvarande inte köpa fler än {n} av denna utbyggnad!",
+                "missingRequirements": "Följande krav är inte uppfyllda:",
+                "summary": {
+                    "available": "{n} redo att byggas",
+                    "built": "{n} byggda",
+                    "inConstruction": "{n} under uppbyggnad",
+                    "total": "{n} möjliga totalt"
+                },
+                "table": { "head": { "building": "Byggnad", "name": "Namn" } },
+                "title": "Utbyggnader",
+                "underConstruction": "under uppbyggnad"
+            },
+            "protocol": {
+                "subtitle": "inga relevanta poster | 1 relevant post | {n} relevanta poster",
+                "table": {
+                    "head": {
+                        "building": "Byggnad",
+                        "label": "Kategori",
+                        "name": "Namn",
+                        "staff": "Personal",
+                        "time": "Tidsstämpel"
+                    }
+                },
+                "title": "Protokoll",
+                "updating": "Uppdaterar..."
+            },
+            "title": "Översikt",
+            "vehicles": {
+                "imageInfo": "Obs: För närvarande kan endast standardikoner för fordon eller de från det valda grafikpaketet visas. Ikoner som ställts in individuellt för ett fordon eller en station kan tyvärr inte kännas igen ännu.",
+                "table": {
+                    "head": {
+                        "building": "Byggnad",
+                        "fms": "Status",
+                        "name": "Namn",
+                        "staff": "Personal (tilldelad / max)"
+                    }
+                },
+                "title": "Fordon"
+            }
+        },
+        "settings": {
+            "abort": "Avbryt",
+            "allianceBuildings": "anslutna alliansbyggnader",
+            "buildings": "anslutna byggnader",
+            "buildingsInList": "Visa anslutna byggnader i byggnadslistan?",
+            "buildingTabs": "Visa flikar för anslutna byggnader?",
+            "dissolve": {
+                "buttons": { "abort": "Avbryt", "continue": "Upplös" },
+                "text": "Vill du upplösa detta byggnadskomplex? Alla anslutna byggnader kommer att visas på kartan igen som tidigare.",
+                "title": "Upplös komplex"
+            },
+            "icon": "Ikon",
+            "iconHelp": "Välj mellan standardikoner och ikoner för anslutna byggnader",
+            "location": "Plats",
+            "name": "Namn",
+            "save": "Spara",
+            "showMarkers": "Visa anslutna byggnader på kartan?",
+            "title": "Redigera komplex"
+        }
+    }
+}

--- a/src/modules/extendedMap/i18n/sv_SE.root.json
+++ b/src/modules/extendedMap/i18n/sv_SE.root.json
@@ -1,0 +1,65 @@
+{
+    "description": "Förbättra kartan med några smarta funktioner.",
+    "mapCSSFilter": {
+        "brightness": "Ljusstyrka",
+        "contrast": "Kontrast",
+        "grayscale": "Gråfilter",
+        "hueRotate": "Nyansrotation",
+        "invert": "Invertera färger",
+        "presets": {
+            "dark1": "Mörk 1",
+            "dark2": "Mörk 2",
+            "dark3": "Mörk 3",
+            "gray": "Grå"
+        },
+        "saturate": "Mättnad",
+        "sepia": "Sepia"
+    },
+    "name": "Förbättrad karta",
+    "positions": {
+        "bottomleft": "Nedre vänster 🡧",
+        "bottomright": "Nedre höger 🡦",
+        "topleft": "Övre vänster 🡤",
+        "topright": "Övre höger 🡥"
+    },
+    "settings": {
+        "buildingComplexes": {
+            "buildings": "Anslutna byggnader",
+            "description": "En designuppdatering som gör det möjligt att slå ihop flera byggnader till en på kartan. Fler inställningar finns i respektive komplex.",
+            "name": "Namn",
+            "position": "Plats",
+            "title": "Byggnadskomplex"
+        },
+        "centerMap": {
+            "description": "Centrera kartan dynamiskt eller till en statisk vy när spelet öppnas",
+            "title": "Centrera karta"
+        },
+        "centerMapStaticLocation": {
+            "title": "Centrera karta statiskt: Position"
+        },
+        "centerMapType": {
+            "description": "Välj om du vill ha statisk eller dynamisk centrering [dynamisk är inte tillgänglig ännu]",
+            "dynamic": "dynamisk",
+            "static": "statisk",
+            "title": "Centrera karta: Läge"
+        },
+        "mapCSSFilter": {
+            "description": "Anpassa kartan med olika CSS-filter för bildredigering. Experimentera gärna och prova dig fram!",
+            "filterFunction": "CSS-filter",
+            "filterValue": "värde",
+            "title": "Kartdesign (CSS-filter)"
+        },
+        "mapScale": {
+            "description": "Visar en kartskala och aktuell zoomnivå",
+            "title": "Skala"
+        },
+        "mapScalePosition": {
+            "description": "Välj i vilket hörn av kartan kartskalan ska visas",
+            "title": "Position för kartskala"
+        },
+        "markerNewWindow": {
+            "description": "Gör det möjligt att öppna uppdrag och byggnader i en ny flik genom Ctrl+klick eller klick med mittenmusknappen.",
+            "title": "Öppna markörer i ny flik"
+        }
+    }
+}


### PR DESCRIPTION
**What kind of update does this PR provide?**
- [x] new translations / updated translations / translation fixes
- [ ] a new feature
- [ ] a new module
- [ ] a bugfix for an existing feature / module
- [ ] improvement of style or user experience
- [ ] other

**Which language(s) did you add/update translations for?**
* sv_SE

**What is included in your update?**
* Adds `sv_SE.root.json` and `sv_SE.json` for the `extendedMap` module, which had no Swedish translation at all before this PR (it was one of only two modules missing sv_SE entirely, alongside `redesign`).
* This fixes `modules.extendedMap.name` showing untranslated ("Improved Map") on the main menu for Swedish users.
* Translates the module's settings (map CSS filters, center-map options, map scale, building complexes) as well as the deeper building-complexes overview panel (buildings/classrooms/extensions/protocol/vehicles tables).

**Additional notes**
These translations have been reviewed by Swedish native eyes before opening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VX32B1yNUVXfN3DDb26nmP